### PR TITLE
add support for full url in config.json

### DIFF
--- a/tap_dynamics/__init__.py
+++ b/tap_dynamics/__init__.py
@@ -89,21 +89,16 @@ class DynamicsAuth(requests.auth.AuthBase):
 @singer.utils.handle_top_exception(LOGGER)
 def main():
     parsed_args = singer.utils.parse_args(REQUIRED_CONFIG_KEYS)
-
-    try:
+   
+    if parsed_args.config.get('full_url'):
+        url = parsed_args.config['full_url']
+    else:
         url = "https://{}.crm.dynamics.com".format(parsed_args.config["org"])
-        auth = DynamicsAuth(parsed_args, url)
-        service_url = url + "/api/data/v9.0/"
-        service = ODataService(
-            service_url, reflect_entities=True, auth=auth 
-        )
-    except:
-        url = "https://{}.crm3.dynamics.com".format(parsed_args.config["org"])
-        auth = DynamicsAuth(parsed_args, url)
-        service_url = url + "/api/data/v9.0/"
-        service = ODataService(
-            service_url, reflect_entities=True, auth=auth 
-        )
+    auth = DynamicsAuth(parsed_args, url)
+    service_url = url + "/api/data/v9.0/"
+    service = ODataService(
+        service_url, reflect_entities=True, auth=auth 
+    )
 
     catalog = parsed_args.catalog or do_discover(service)
     if parsed_args.discover:


### PR DESCRIPTION
### Description of change
- Add support for custom urls 
config.json:
` "full_url": "https://org77f82e3b.crm3.dynamics.com",`

### Rollback steps
 - revert this branch
### Task
[Linear Task](https://linear.app/hotglue/issue/HGI-1528/[goodkind]-add-support-for-nonstandard-org-ids-in-tap-dynamics)